### PR TITLE
Devops | DATA-870 | Add BB_BUILD_TIMESTAMP with segment meta data.

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -88,6 +88,9 @@ function getSegmentMetadata() {
   // Get the module options to we can pass the write key. The write key is a public key.
   const moduleOptions = JSON.parse(OPTIONS)
 
+  // Build timestamp for tracking what build a user is on
+  const currentBuildTimestamp = process.env.BUILD_TIMESTAMP
+
   const gaCID = Cookies.get('_ga')
   const gaID = Cookies.get('_gid')
   const dyID = Cookies.get('_dyid')
@@ -107,6 +110,7 @@ function getSegmentMetadata() {
   }
 
   return {
+    bb_build_timestamp: currentBuildTimestamp,
     session_id: sessionId,
     user_id: userID,
     email: email,
@@ -285,5 +289,7 @@ export default function (context, inject) {
   if (Vue.$segment) {
     inject('segment', Vue.$segment)
   }
+
+  // We could pass in the nuxt context into this function and tack on the build timestamp there rather than process.env.bb_build_timestamp
   startPageTracking(app, $config)
 }


### PR DESCRIPTION
**Links:**

- Jira Ticket URL: https://bollandbranch.atlassian.net/browse/DATA-870
- Related PRs: 
   - https://github.com/boll-branch/boll-and-branch/pull/954
   - https://github.com/boll-branch/boll-branch-nacelle/pull/898

**Steps**
1. Checkout this branch locally: `devops/DATA-822/add-build-timestamp-to-metadata`
2. Run `yarn` to make sure you have the most up to date lockfile and node modules
3.  Run `yarn link` from the project root
4. Open the  `boll-branch-nacelle` repository with your IDE/Code editor(Any branch should be fine for verifying) and run `npm install` to ensure your lock file and node modules are up to date
5. Run `yarn link "@dansmaculotte/nuxt-segment"`, if everything went well you should be able to see this icon in your file tree under `./node_modules/@dansmaculotte/nuxt-segment`. And the `plugins.js` file within that directory should have the updated code from this branch. 
<img width="191" alt="Screen Shot 2022-05-02 at 4 16 49 PM" src="https://user-images.githubusercontent.com/24883328/166341981-cf81bdea-7bc4-4d6d-bc84-12807d04f230.png">

6. Run `npm run dev`
7. Open the browser and go to `localhost:3000`, open up Chrome DevTools to the `network` tab and within the request filter search bar type in `segment` to display the segment requests. Trigger a `Page` or `Page Viewed` event and you should be able to see a `bb_build_timestamp` property within the requests payload.
<img width="600" alt="Screen Shot 2022-05-02 at 4 42 18 PM" src="https://user-images.githubusercontent.com/24883328/166343220-dc842ee9-b948-4833-8ea1-f4d6c738e69e.png">

8. After verification is complete, run `yarn unlink` within the `boll-branch-nacelle` project to unlink the local package from the dependencies. And within the `nuxt-segment` project run `yarn unlink` to remove the project from the linked registry.

