### PR TITLE
Fix | No-Ticket | Access build timestamp through config

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -48,7 +48,7 @@ function segmentCategory(to) {
  * @return {String}
  *          The name of the referred website.
  * */
-function getDocumentReferrer(){
+function getDocumentReferrer() {
   let referrer = ''
   const referrerKey = '_bb_user_referrer'
   if (process.client) {
@@ -83,13 +83,17 @@ function getUtm(params) {
  *
  * _session_id is only set on the bollandbranch.com domain so won't come on local or preview testing without being set
  * up as a preview on the root domain.
+ * 
+ * @param {Object} $config - Nuxt App config, provides runtime environment variables that are available to both the client and server.
+ * @param {string} $config.BUILD_TIMESTAMP - The current build timestamp for an app instance.
+ * 
  * */
-function getSegmentMetadata() {
+function getSegmentMetadata($config) {
   // Get the module options to we can pass the write key. The write key is a public key.
   const moduleOptions = JSON.parse(OPTIONS)
 
   // Build timestamp for tracking what build a user is on
-  const currentBuildTimestamp = process.env.BUILD_TIMESTAMP
+  const currentBuildTimestamp = $config.BUILD_TIMESTAMP
 
   const gaCID = Cookies.get('_ga')
   const gaID = Cookies.get('_gid')
@@ -191,7 +195,7 @@ function getAmplitudeIntegrations() {
   }
 }
 
-function startPageTracking(app) {
+function startPageTracking(app, $config) {
   app.router.afterEach((to, from) => {
 
     const redirectCookie = Cookies.get('redirect-path')
@@ -207,7 +211,7 @@ function startPageTracking(app) {
         }
         window.analytics.page(segmentCategory(toObj),(typeof document !== 'undefined' && document.title) || '',
           {
-            ...getSegmentMetadata(),
+            ...getSegmentMetadata($config),
             ...getSegmentPageData(toObj),
             path: toObj.path,
             site: 'pwa'
@@ -219,7 +223,7 @@ function startPageTracking(app) {
           window.analytics.track(
             'Page Viewed',
             {
-              ...getSegmentMetadata(),
+              ...getSegmentMetadata($config),
               ...getSegmentPageData(toObj),
               category: segmentCategory(toObj),
               scroll_depth: getScrollPercent()
@@ -237,7 +241,7 @@ function startPageTracking(app) {
     try {
       setTimeout(() => {
         window.analytics.page(segmentCategory(to), (typeof document !== 'undefined' && document.title) || '', {
-            ...getSegmentMetadata(),
+            ...getSegmentMetadata($config),
             ...getSegmentPageData(to),
             path: to.fullPath,
             site: 'pwa',
@@ -248,7 +252,7 @@ function startPageTracking(app) {
           'Page Viewed',
           {
             ...getSegmentPageData(to),
-            ...getSegmentMetadata(),
+            ...getSegmentMetadata($config),
             category: segmentCategory(to),
             scroll_depth: getScrollPercent()
           },
@@ -290,6 +294,5 @@ export default function (context, inject) {
     inject('segment', Vue.$segment)
   }
 
-  // We could pass in the nuxt context into this function and tack on the build timestamp there rather than process.env.bb_build_timestamp
   startPageTracking(app, $config)
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dansmaculotte/nuxt-segment",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Nuxt.js module for Segment Analytics.js",
   "license": "MIT",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dansmaculotte/nuxt-segment",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "Nuxt.js module for Segment Analytics.js",
   "license": "MIT",
   "contributors": [


### PR DESCRIPTION
Notes:
 - Fixes the undefined `BUILD_TIMESTAMP` when accessing from the current process environment. In the Nacelle RC that went out, the `publicRuntimeConfig` key was introduced which allows environment variables assigned to that object to be available for both the Client and Server. With this change we need to grab the `BUILD_TIMESTAMP` from the Nuxt app's `$config` object and pass it to the functions where we call `segmentMetaData`